### PR TITLE
Hot-pixel detection and thresholding

### DIFF
--- a/pguresvt.py
+++ b/pguresvt.py
@@ -95,7 +95,8 @@ class SVT(object):
                 sigma=-1.,                
                 arpssize=7, 
                 tol=1e-7,
-                median=5
+                median=5,
+                hotpixelthreshold=10
                 ):
                     
         self.patchsize = patchsize
@@ -109,6 +110,7 @@ class SVT(object):
         self.arpssize = arpssize
         self.tol = tol
         self.median = median
+        self.hotpixelthreshold = hotpixelthreshold
         
         # Setup ctypes function
         libpath = os.path.dirname(os.path.abspath(__file__)) + '/build/libpguresvt.so'
@@ -127,7 +129,8 @@ class SVT(object):
                                    ctypes.c_double,
                                    ctypes.c_int,
                                    ctypes.c_double,
-                                   ctypes.c_int]
+                                   ctypes.c_int
+                                   ctypes.c_double]
 
         self.Y = None
         
@@ -179,7 +182,8 @@ class SVT(object):
                                 self.sigma,
                                 self.arpssize,
                                 self.tol,
-                                self.median)
+                                self.median
+                                self.hotpixelthreshold)
         self.Y = Y
         return Y
 

--- a/src/PGURE-SVT.cpp
+++ b/src/PGURE-SVT.cpp
@@ -71,6 +71,7 @@ extern "C" {
 
 // Own headers
 #include "arps.hpp"
+#include "hotpixel.hpp"
 #include "params.hpp"
 #include "noise.hpp"
 #include "pgure.hpp"
@@ -262,34 +263,7 @@ int main(int argc, char** argv) {
 
     // Initial outlier detection (for hot pixels)
     // using median absolute deviation
-    std::cout<<std::endl<<"Applying hot-pixel detector with threshold: "<<hotpixelthreshold<<" * MAD"<<std::endl;
-    for (int i = 0; i < T; i++) {
-        double median = arma::median(arma::vectorise(noisysequence.slice(i)));
-        double medianAbsDev = arma::median(
-                                    arma::vectorise(
-                                      arma::abs(
-                                        noisysequence.slice(i) - median))) / 0.6745;
-        arma::uvec outliers = arma::find(arma::abs(noisysequence.slice(i)-median) > hotpixelthreshold*medianAbsDev);
-        for (size_t j = 0; j < outliers.n_elem; j++) {
-            arma::uvec sub = arma::ind2sub(arma::size(Nx,Ny), outliers(j));
-            arma::vec medianwindow(8);
-            if ((int)sub(0) > 0 
-                && (int)sub(0) < Nx-1 
-                && (int)sub(1) > 0 
-                && (int)sub(1) < Ny-1) {
-                medianwindow(0) = noisysequence(sub(0)-1, sub(1)-1, i);
-                medianwindow(0) = noisysequence(sub(0)-1, sub(1), i);
-                medianwindow(0) = noisysequence(sub(0)-1, sub(1)+1, i);
-                medianwindow(0) = noisysequence(sub(0), sub(1)-1, i);
-                medianwindow(0) = noisysequence(sub(0), sub(1)+1, i);
-                medianwindow(0) = noisysequence(sub(0)+1, sub(1)-1, i);
-                medianwindow(0) = noisysequence(sub(0)+1, sub(1), i);
-                medianwindow(0) = noisysequence(sub(0)+1, sub(1)+1, i);
-            }
-            medianwindow = arma::sort(medianwindow);
-            noisysequence(sub(0), sub(1), i) = (medianwindow(3) + medianwindow(4))/2;
-        }
-    }
+    HotPixelFilter(noisysequence, hotpixelthreshold);
     
 	/////////////////////////////
 	//						   //

--- a/src/hotpixel.hpp
+++ b/src/hotpixel.hpp
@@ -58,16 +58,23 @@ void HotPixelFilter(arma::cube &sequence,
                 && (int)sub(1) > 0 
                 && (int)sub(1) < Ny-1) {
                 medianwindow(0) = sequence(sub(0)-1, sub(1)-1, i);
-                medianwindow(0) = sequence(sub(0)-1, sub(1), i);
-                medianwindow(0) = sequence(sub(0)-1, sub(1)+1, i);
-                medianwindow(0) = sequence(sub(0), sub(1)-1, i);
-                medianwindow(0) = sequence(sub(0), sub(1)+1, i);
-                medianwindow(0) = sequence(sub(0)+1, sub(1)-1, i);
-                medianwindow(0) = sequence(sub(0)+1, sub(1), i);
-                medianwindow(0) = sequence(sub(0)+1, sub(1)+1, i);
-            }
-            medianwindow = arma::sort(medianwindow);
-            sequence(sub(0), sub(1), i) = (medianwindow(3) + medianwindow(4))/2;
+                medianwindow(1) = sequence(sub(0)-1, sub(1), i);
+                medianwindow(2) = sequence(sub(0)-1, sub(1)+1, i);
+                medianwindow(3) = sequence(sub(0), sub(1)-1, i);
+                medianwindow(4) = sequence(sub(0), sub(1)+1, i);
+                medianwindow(5) = sequence(sub(0)+1, sub(1)-1, i);
+                medianwindow(6) = sequence(sub(0)+1, sub(1), i);
+                medianwindow(7) = sequence(sub(0)+1, sub(1)+1, i);
+                
+                medianwindow = arma::sort(medianwindow);
+                sequence(sub(0), sub(1), i) = (medianwindow(3) + medianwindow(4))/2;
+            } else {
+                // Edge pixels are replaced by the median
+                // of the frame (as they are not *usually*
+                // very important! CAREFUL THOUGH)
+                sequence(sub(0), sub(1), i) = median; 
+            }         
+            
         }
     }
     return;

--- a/src/hotpixel.hpp
+++ b/src/hotpixel.hpp
@@ -1,0 +1,76 @@
+/***************************************************************************
+
+    Copyright (C) 2015-16 Tom Furnival
+
+    This file is part of PGURE-SVT.
+
+    PGURE-SVT is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    PGURE-SVT is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with PGURE-SVT. If not, see <http://www.gnu.org/licenses/>.
+
+***************************************************************************/
+
+#ifndef HOTPIXEL_H
+#define HOTPIXEL_H
+
+// C++ headers
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+// Armadillo library
+#include <armadillo>
+
+void HotPixelFilter(arma::cube &sequence,
+                    double threshold) {
+    int Nx = sequence.n_rows;
+    int Ny = sequence.n_cols;
+    int T = sequence.n_slices;
+    
+    std::cout << std::endl
+              << "Applying hot-pixel detector with threshold: "
+              << threshold
+              << " * MAD"
+              << std::endl;
+              
+    for (int i = 0; i < T; i++) {
+        double median = arma::median(arma::vectorise(sequence.slice(i)));
+        double medianAbsDev = arma::median(
+                                    arma::vectorise(
+                                      arma::abs(
+                                        sequence.slice(i) - median))) / 0.6745;
+        arma::uvec outliers = arma::find(arma::abs(sequence.slice(i)-median) > threshold*medianAbsDev);
+        for (size_t j = 0; j < outliers.n_elem; j++) {
+            arma::uvec sub = arma::ind2sub(arma::size(Nx,Ny), outliers(j));
+            arma::vec medianwindow(8);
+            if ((int)sub(0) > 0 
+                && (int)sub(0) < Nx-1 
+                && (int)sub(1) > 0 
+                && (int)sub(1) < Ny-1) {
+                medianwindow(0) = sequence(sub(0)-1, sub(1)-1, i);
+                medianwindow(0) = sequence(sub(0)-1, sub(1), i);
+                medianwindow(0) = sequence(sub(0)-1, sub(1)+1, i);
+                medianwindow(0) = sequence(sub(0), sub(1)-1, i);
+                medianwindow(0) = sequence(sub(0), sub(1)+1, i);
+                medianwindow(0) = sequence(sub(0)+1, sub(1)-1, i);
+                medianwindow(0) = sequence(sub(0)+1, sub(1), i);
+                medianwindow(0) = sequence(sub(0)+1, sub(1)+1, i);
+            }
+            medianwindow = arma::sort(medianwindow);
+            sequence(sub(0), sub(1), i) = (medianwindow(3) + medianwindow(4))/2;
+        }
+    }
+    return;
+}
+
+#endif

--- a/src/lib-PGURE-SVT.cpp
+++ b/src/lib-PGURE-SVT.cpp
@@ -87,7 +87,8 @@ extern "C" int PGURESVT(double *X,
                         double sigma,
                         int MotionP,
                         double tol,
-                        int MedianSize) {
+                        int MedianSize,
+                        double hotpixelthreshold) {
 
 	// Overall program timer
 	auto overallstart = std::chrono::steady_clock::now();
@@ -138,14 +139,14 @@ extern "C" int PGURESVT(double *X,
 
     // Initial outlier detection (for hot pixels)
     // using median absolute deviation
+    std::cout<<std::endl<<"Applying hot-pixel detector with threshold: "<<hotpixelthreshold<<std::endl;
     for (int i = 0; i < T; i++) {
         double median = arma::median(arma::vectorise(noisysequence.slice(i)));
         double medianAbsDev = arma::median(
                                     arma::vectorise(
                                       arma::abs(
                                         noisysequence.slice(i) - median))) / 0.6745;
-        
-        arma::uvec outliers = arma::find(arma::abs(noisysequence.slice(i)-median) > 2.5*medianAbsDev);
+        arma::uvec outliers = arma::find(arma::abs(noisysequence.slice(i)-median) > 10*medianAbsDev);
         for (size_t j = 0; j < outliers.n_elem; j++) {
             arma::uvec sub = arma::ind2sub(arma::size(Nx,Ny), outliers(j));
             arma::vec medianwindow(8);

--- a/src/lib-PGURE-SVT.cpp
+++ b/src/lib-PGURE-SVT.cpp
@@ -66,6 +66,7 @@ extern "C" {
 
 // Own headers
 #include "arps.hpp"
+#include "hotpixel.hpp"
 #include "params.hpp"
 #include "noise.hpp"
 #include "pgure.hpp"
@@ -139,34 +140,7 @@ extern "C" int PGURESVT(double *X,
 
     // Initial outlier detection (for hot pixels)
     // using median absolute deviation
-    std::cout<<std::endl<<"Applying hot-pixel detector with threshold: "<<hotpixelthreshold<<std::endl;
-    for (int i = 0; i < T; i++) {
-        double median = arma::median(arma::vectorise(noisysequence.slice(i)));
-        double medianAbsDev = arma::median(
-                                    arma::vectorise(
-                                      arma::abs(
-                                        noisysequence.slice(i) - median))) / 0.6745;
-        arma::uvec outliers = arma::find(arma::abs(noisysequence.slice(i)-median) > 10*medianAbsDev);
-        for (size_t j = 0; j < outliers.n_elem; j++) {
-            arma::uvec sub = arma::ind2sub(arma::size(Nx,Ny), outliers(j));
-            arma::vec medianwindow(8);
-            if ((int)sub(0) > 0 
-                && (int)sub(0) < Nx-1 
-                && (int)sub(1) > 0 
-                && (int)sub(1) < Ny-1) {
-                medianwindow(0) = noisysequence(sub(0)-1, sub(1)-1, i);
-                medianwindow(0) = noisysequence(sub(0)-1, sub(1), i);
-                medianwindow(0) = noisysequence(sub(0)-1, sub(1)+1, i);
-                medianwindow(0) = noisysequence(sub(0), sub(1)-1, i);
-                medianwindow(0) = noisysequence(sub(0), sub(1)+1, i);
-                medianwindow(0) = noisysequence(sub(0)+1, sub(1)-1, i);
-                medianwindow(0) = noisysequence(sub(0)+1, sub(1), i);
-                medianwindow(0) = noisysequence(sub(0)+1, sub(1)+1, i);
-            }
-            medianwindow = arma::sort(medianwindow);
-            noisysequence(sub(0), sub(1), i) = (medianwindow(3) + medianwindow(4))/2;
-        }
-    }
+    HotPixelFilter(noisysequence, hotpixelthreshold);
     
 	/////////////////////////////
 	//						   //

--- a/src/params.hpp
+++ b/src/params.hpp
@@ -2,7 +2,7 @@
 
     Copyright (C) 2015-16 Tom Furnival
 
-    This file is part of  PGURE-SVT.
+    This file is part of PGURE-SVT.
 
     PGURE-SVT is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Simple detector for hot pixels (e.g. encountered with a CCD camera) that uses the Median Absolute Deviation as the threshold, then replaces the pixel with the median of its 8 nearest pixels.
#13
