### PR TITLE
Keep metadata signal

### DIFF
--- a/examples/PGURE-SVT-HyperSpy-Demo.ipynb
+++ b/examples/PGURE-SVT-HyperSpy-Demo.ipynb
@@ -78,7 +78,7 @@
    "source": [
     "random_state = 123\n",
     "detector_gain = 0.1\n",
-    "detector_offset = 0.1\n",
+    "detector_offset = 0.5\n",
     "detector_sigma = 0.1\n",
     "\n",
     "noisy_data = mixed_noise_model(\n",
@@ -228,7 +228,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,

--- a/pguresvt/hspy.py
+++ b/pguresvt/hspy.py
@@ -68,7 +68,12 @@ class HSPYSVT(SVT):
 
         super(HSPYSVT, self).denoise(self._X)
 
-        denoised_signal = signal._deepcopy_with_new_data(self.Y_.T)
+        if self._signal_type == "spectrum":
+            axes = (1, 0)
+        elif self._signal_type == "image":
+            axes = (2, 0, 1)
+
+        denoised_signal = signal._deepcopy_with_new_data(self.Y_.transpose(axes))
         new_title = f"Denoised {signal.metadata.General.title}".strip()
         denoised_signal.metadata.General.title = new_title
 

--- a/pguresvt/hspy.py
+++ b/pguresvt/hspy.py
@@ -1,8 +1,6 @@
 # Author: Tom Furnival
 # License: GPLv3
 
-from hyperspy.signals import BaseSignal
-
 from .svt import SVT
 
 
@@ -52,16 +50,6 @@ class HSPYSVT(SVT):
                 f"Expected 1D or 2D signal - got dimension {sig_dim}"
             )
 
-    def _denoised_data_to_signal(self):
-        """Converts denoised data back to a HyperSpy signal."""
-        signal = BaseSignal(self.Y_)
-
-        if self._signal_type == "spectrum":
-            return signal.as_signal1D(2)
-
-        if self._signal_type == "image":
-            return signal.as_signal2D((1, 2))
-
     def denoise(self, signal):
         """Denoises an arbitrary HyperSpy signal.
 
@@ -80,4 +68,4 @@ class HSPYSVT(SVT):
 
         super(HSPYSVT, self).denoise(self._X)
 
-        return self._denoised_data_to_signal()
+        return signal._deepcopy_with_new_data(self.Y_.T)

--- a/pguresvt/hspy.py
+++ b/pguresvt/hspy.py
@@ -68,4 +68,8 @@ class HSPYSVT(SVT):
 
         super(HSPYSVT, self).denoise(self._X)
 
-        return signal._deepcopy_with_new_data(self.Y_.T)
+        denoised_signal = signal._deepcopy_with_new_data(self.Y_.T)
+        new_title = f"Denoised {signal.metadata.General.title}".strip()
+        denoised_signal.metadata.General.title = new_title
+
+        return denoised_signal

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ extensions = [
         "pguresvt._pguresvt",
         sources=["pguresvt/_pguresvt.pyx"],
         include_dirs=["pguresvt/", "src/", np.get_include()],
-        libraries=["openblas", "lapack", "armadillo", "nlopt"],
+        libraries=["lapack", "armadillo", "nlopt"],
         language="c++",
         extra_compile_args=[
             "-fPIC",


### PR DESCRIPTION
- [x] Keep metadata from the original signal
- [x] Add _denoised_ suffix to signal title 
- [x] fix example notebook (negative value error).
- [x] Remove optional openblas dependency.

For the last item, I don't know if this is the better approach to deal with this optional dependency of the C extensions.